### PR TITLE
Fix array items to also handle raw types

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,3 @@ DEPENDENCIES
   guard-minitest
   nidyx!
   terminal-notifier-guard
-
-BUNDLED WITH
-   1.10.6

--- a/lib/nidyx/objc/mapper.rb
+++ b/lib/nidyx/objc/mapper.rb
@@ -3,6 +3,9 @@ require "nidyx/objc/model"
 require "nidyx/objc/interface"
 require "nidyx/objc/implementation"
 require "nidyx/objc/property"
+require "nidyx/objc/utils"
+
+include Nidyx::ObjCUtils
 
 module Nidyx
   module ObjCMapper
@@ -29,7 +32,7 @@ module Nidyx
     def map_interface(model, options)
       interface = Nidyx::ObjCInterface.new(model.name, options)
       interface.properties = model.properties.map { |p| Nidyx::ObjCProperty.new(p) }
-      interface.imports += model.dependencies.to_a
+      interface.imports += filter_primitives(model.dependencies.to_a)
       interface
     end
 

--- a/lib/nidyx/objc/property.rb
+++ b/lib/nidyx/objc/property.rb
@@ -1,11 +1,13 @@
 require "set"
+require "nidyx/objc/utils"
+
+include Nidyx::ObjCUtils
 
 module Nidyx
   class ObjCProperty
+
     attr_reader :name, :attributes, :type, :type_name, :desc, :getter_override,
                 :protocols
-
-    class UnsupportedEnumTypeError < StandardError; end
 
     # @param property [Property] generic property
     def initialize(property)
@@ -19,7 +21,8 @@ module Nidyx
       @type_name = lookup_type_name(@type, property.class_name)
 
       @protocols = []
-      @protocols += property.collection_types if property.collection_types
+      # Exclude any primitive types for collections
+      @protocols += filter_primitives(property.collection_types) if property.collection_types
       @protocols << "Optional" if @optional
     end
 
@@ -36,139 +39,6 @@ module Nidyx
     # @return [String] the property's protocols, comma separated
     def protocols_string
       @protocols.join(", ")
-    end
-
-    private
-
-    PRIMITIVE_ATTRIBUTES = "assign, nonatomic"
-    OBJECT_ATTRIBUTES = "strong, nonatomic"
-
-    ATTRIBUTES = {
-      :array      => OBJECT_ATTRIBUTES,
-      :boolean    => PRIMITIVE_ATTRIBUTES,
-      :integer    => PRIMITIVE_ATTRIBUTES,
-      :unsigned   => PRIMITIVE_ATTRIBUTES,
-      :number     => PRIMITIVE_ATTRIBUTES,
-      :number_obj => OBJECT_ATTRIBUTES,
-      :string     => OBJECT_ATTRIBUTES,
-      :object     => OBJECT_ATTRIBUTES,
-      :id         => OBJECT_ATTRIBUTES
-    }
-
-    # Objective-C types
-    # :object intentionally omitted
-    TYPES = {
-      :array      => "NSArray",
-      :boolean    => "BOOL",
-      :integer    => "NSInteger",
-      :unsigned   => "NSUInteger",
-      :number     => "double",
-      :number_obj => "NSNumber",
-      :string     => "NSString",
-      :id         => "id"
-    }
-
-    # Hash and Array intentionally omitted
-    ENUM_TYPES = {
-      Fixnum     => :integer,
-      String     => :string,
-      NilClass   => :null,
-      Float      => :number,
-      TrueClass  => :boolean,
-      FalseClass => :boolean
-    }
-
-    OBJECTS = Set.new [:array, :number_obj, :string, :object, :id]
-
-    SIMPLE_NUMBERS = Set.new [:unsigned, :integer, :number]
-
-    BOXABLE_NUMBERS = SIMPLE_NUMBERS + [:boolean]
-
-    FORBIDDEN_PROPERTY_PREFIXES = ["new", "copy"]
-
-    # @param type [Symbol] an obj-c property type
-    # @param class_name [String] an object's type name
-    # @return [String] the property's type name
-    def lookup_type_name(type, class_name)
-      type == :object ? class_name : TYPES[type]
-    end
-
-    # @param property [Property] generic property
-    # @return [Symbol] an obj-c property type
-    def process_type(property)
-      return process_enum_type(property) if property.enum
-
-      type = property.type
-      if type.is_a?(Set)
-        process_array_type(type, property)
-      else
-        process_simple_type(type, property)
-      end
-    end
-
-
-    # @param property [Property] generic property
-    # @return [Symbol] an obj-c property type
-    def process_enum_type(property)
-      enum = property.enum
-
-      # map enum to a set of types
-      types = enum.map { |a| a.class }
-      raise UnsupportedEnumTypeError unless (types & [ Array, Hash ]).empty?
-      types = Set.new(types.map { |t| ENUM_TYPES[t] })
-
-      process_array_type(types, property)
-    end
-
-    # @param type [Symbol] a property type symbol
-    # @param property [Property] generic property
-    # @return [Symbol] an obj-c property type
-    def process_simple_type(type, property)
-      case type
-      when :boolean, :number, :integer
-        return :number_obj if @optional
-        if type == :integer && property.minimum && property.minimum >= 0
-          return :unsigned
-        end
-        type
-
-      when :null
-        @optional = true
-        :id
-
-      when :object
-        property.has_properties? ? :object : :id
-
-      else
-        type
-      end
-    end
-
-    # @param type [Set] an array of property types
-    # @param property [Property] generic property
-    # @return [Symbol] an obj-c property type
-    def process_array_type(types, property)
-      # if the key is optional
-      @optional = true if types.delete?(:null)
-
-      # single optional type
-      return process_simple_type(types.to_a.shift, property) if types.size == 1
-
-      # conjoined number types
-      return :number if types.subset?(SIMPLE_NUMBERS) && !@optional
-      return :number_obj if types.subset?(BOXABLE_NUMBERS)
-
-      :id
-    end
-
-    # @param name [String] the property name
-    # @return [String, nil] the getter override string if necessary
-    def process_getter_override(name)
-      FORBIDDEN_PROPERTY_PREFIXES.each do |p|
-        return ", getter=get#{name.camelize}" if name.match(/^#{p}[_A-Z].*/)
-      end
-
-      nil
     end
   end
 end

--- a/lib/nidyx/objc/utils.rb
+++ b/lib/nidyx/objc/utils.rb
@@ -1,0 +1,144 @@
+module Nidyx
+  module ObjCUtils
+    module_function
+
+    class UnsupportedEnumTypeError < StandardError; end
+
+    PRIMITIVE_ATTRIBUTES = "assign, nonatomic"
+    OBJECT_ATTRIBUTES = "strong, nonatomic"
+
+    ATTRIBUTES = {
+      :array      => OBJECT_ATTRIBUTES,
+      :boolean    => PRIMITIVE_ATTRIBUTES,
+      :integer    => PRIMITIVE_ATTRIBUTES,
+      :unsigned   => PRIMITIVE_ATTRIBUTES,
+      :number     => PRIMITIVE_ATTRIBUTES,
+      :number_obj => OBJECT_ATTRIBUTES,
+      :string     => OBJECT_ATTRIBUTES,
+      :object     => OBJECT_ATTRIBUTES,
+      :id         => OBJECT_ATTRIBUTES
+    }
+
+    # Objective-C types
+    # :object intentionally omitted
+    TYPES = {
+      :array      => "NSArray",
+      :boolean    => "BOOL",
+      :integer    => "NSInteger",
+      :unsigned   => "NSUInteger",
+      :number     => "double",
+      :number_obj => "NSNumber",
+      :string     => "NSString",
+      :id         => "id"
+    }
+
+    # Hash and Array intentionally omitted
+    ENUM_TYPES = {
+      Fixnum     => :integer,
+      String     => :string,
+      NilClass   => :null,
+      Float      => :number,
+      TrueClass  => :boolean,
+      FalseClass => :boolean
+    }
+
+    OBJECTS = Set.new [:array, :number_obj, :string, :object, :id]
+
+    SIMPLE_NUMBERS = Set.new [:unsigned, :integer, :number]
+
+    BOXABLE_NUMBERS = SIMPLE_NUMBERS + [:boolean]
+
+    FORBIDDEN_PROPERTY_PREFIXES = ["new", "copy"]
+
+    # @param type (Array[String|Symbol]) collection of types
+    # @return (Array[Symbol]) the collection w/out primitive types
+    def filter_primitives(ts)
+      ts.reject{|t| TYPES.keys.include?(t.to_sym)}
+    end
+
+    # @param type [Symbol] an obj-c property type
+    # @param class_name [String] an object's type name
+    # @return [String] the property's type name
+    def lookup_type_name(type, class_name)
+      type == :object ? class_name : TYPES[type]
+    end
+    
+    # @param property [Property] generic property
+    # @return [Symbol] an obj-c property type
+    def process_type(property)
+      return process_enum_type(property) if property.enum
+
+      type = property.type
+      if type.is_a?(Set)
+        process_array_type(type, property)
+      else
+        process_simple_type(type, property)
+      end
+    end
+
+    # @param property [Property] generic property
+    # @return [Symbol] an obj-c property type
+    def process_enum_type(property)
+      enum = property.enum
+
+      # map enum to a set of types
+      types = enum.map { |a| a.class }
+      raise UnsupportedEnumTypeError unless (types & [ Array, Hash ]).empty?
+      types = Set.new(types.map { |t| ENUM_TYPES[t] })
+
+      process_array_type(types, property)
+    end
+
+    # @param type [Symbol] a property type symbol
+    # @param property [Property] generic property
+    # @return [Symbol] an obj-c property type
+    def process_simple_type(type, property)
+      case type
+      when :boolean, :number, :integer
+        return :number_obj if @optional
+        if type == :integer && property.minimum && property.minimum >= 0
+          return :unsigned
+        end
+        type
+
+      when :null
+        @optional = true
+        :id
+
+      when :object
+        property.has_properties? ? :object : :id
+
+      else
+        type
+      end
+    end
+
+    # @param type [Set] an array of property types
+    # @param property [Property] generic property
+    # @return [Symbol] an obj-c property type
+    def process_array_type(types, property)
+      # if the key is optional
+      @optional = true if types.delete?(:null)
+
+      # single optional type
+      return process_simple_type(types.to_a.shift, property) if types.size == 1
+
+      # conjoined number types
+      return :number if types.subset?(SIMPLE_NUMBERS) && !@optional
+      return :number_obj if types.subset?(BOXABLE_NUMBERS)
+
+      :id
+    end
+
+    # @param name [String] the property name
+    # @return [String, nil] the getter override string if necessary
+    def process_getter_override(name)
+      FORBIDDEN_PROPERTY_PREFIXES.each do |p|
+        return ", getter=get#{name.camelize}" if name.match(/^#{p}[_A-Z].*/)
+      end
+
+      nil
+    end
+
+  end
+end

--- a/lib/nidyx/parser.rb
+++ b/lib/nidyx/parser.rb
@@ -135,6 +135,7 @@ module Nidyx
     # @return [Array] types contained in the array
     def resolve_array_refs(obj)
       items = obj[ITEMS_KEY]
+
       case items
       when Array
         return resolve_items_array(items)
@@ -154,11 +155,22 @@ module Nidyx
     # @return [Array] types contained in the array
     def resolve_items_array(items)
       types = []
-      items.each do |item|
-        resolve_reference_string(item[REF_KEY])
-        types << class_name_from_ref(item[REF_KEY])
+      items.each do |i|
+        types << resolve_single_item(i)
       end
+
       types.compact
+    end
+
+    # @param item (Hash) a single item
+    # return (Array) types for the single item
+    def resolve_single_item(item)
+      if item[REF_KEY]
+        resolve_reference_string(item[REF_KEY])
+        class_name_from_ref(item[REF_KEY])
+      elsif item[TYPE_KEY]
+        item[TYPE_KEY]
+      end
     end
 
     # @param ref [String] reference in json pointer format

--- a/test/nidyx/objc/test_property.rb
+++ b/test/nidyx/objc/test_property.rb
@@ -1,7 +1,10 @@
 require "minitest/autorun"
 require "nidyx"
+require "nidyx/parse_constants"
 require "nidyx/property"
 require "nidyx/objc/property"
+
+include Nidyx::ParseConstants
 
 class TestObjCProperty < Minitest::Test
 
@@ -19,7 +22,7 @@ class TestObjCProperty < Minitest::Test
   end
 
   def test_simple_array
-    obj = { "type" => "array" }
+    obj = { TYPE_KEY => "array" }
     p = property(obj, false)
     assert_equal(:array, p.type)
     assert_equal(nil, p.getter_override)
@@ -34,14 +37,21 @@ class TestObjCProperty < Minitest::Test
   end
 
   def test_typed_optional_array
-    obj = { "type" => ["array", "null"] }
+    obj = { TYPE_KEY => ["array", "null"] }
     p = property(obj, false)
     assert_equal(:array, p.type)
     assert_equal(["Optional"], p.protocols)
   end
 
+  def test_typed_array_with_protocls
+    obj = { TYPE_KEY => ["array" ], COLLECTION_TYPES_KEY => ["aClass", "string"]  }
+    p = property(obj, false)
+    assert_equal(:array, p.type)
+    assert_equal(["aClass"], p.protocols)
+  end
+
   def test_boolean
-    obj = { "type" => "boolean" }
+    obj = { TYPE_KEY => "boolean" }
     p = property(obj, false)
     assert_equal(:boolean, p.type)
 
@@ -51,13 +61,13 @@ class TestObjCProperty < Minitest::Test
   end
 
   def test_typed_optional_boolean
-    obj = { "type" => ["boolean", "null"] }
+    obj = { TYPE_KEY => ["boolean", "null"] }
     p = property(obj, false)
     assert_equal(:number_obj, p.type)
   end
 
   def test_integer
-    obj = { "type" => "integer" }
+    obj = { TYPE_KEY => "integer" }
     p = property(obj, false)
     assert_equal(:integer, p.type)
 
@@ -67,20 +77,20 @@ class TestObjCProperty < Minitest::Test
   end
 
   def test_unsigned_integer
-    obj = { "type" => "integer", "minimum" => 0 }
+    obj = { TYPE_KEY => "integer", "minimum" => 0 }
     p = property(obj, false)
     assert_equal(:unsigned, p.type)
   end
 
   def test_typed_optional_integer
-    obj = { "type" => ["integer", "null"] }
+    obj = { TYPE_KEY => ["integer", "null"] }
     p = property(obj, false)
     assert_equal(:number_obj, p.type)
     assert_equal(["Optional"], p.protocols)
   end
 
   def test_number
-    obj = { "type" => "number" }
+    obj = { TYPE_KEY => "number" }
     p = property(obj, false)
     assert_equal(:number, p.type)
 
@@ -89,13 +99,13 @@ class TestObjCProperty < Minitest::Test
   end
 
   def test_typed_optional_number
-    obj = { "type" => ["number", "null"] }
+    obj = { TYPE_KEY => ["number", "null"] }
     p = property(obj, false)
     assert_equal(:number_obj, p.type)
   end
 
   def test_string
-    obj = { "type" => "string" }
+    obj = { TYPE_KEY => "string" }
     p = property(obj, false)
     assert_equal(:string, p.type)
 
@@ -104,15 +114,15 @@ class TestObjCProperty < Minitest::Test
   end
 
   def test_typed_optional_string
-    obj = { "type" => ["string", "null"] }
+    obj = { TYPE_KEY => ["string", "null"] }
     p = property(obj, false)
     assert_equal(:string, p.type)
   end
 
   def test_object
     obj = {
-      "type" => "object",
-      "properties" => {}
+      TYPE_KEY => "object",
+      PROPERTIES_KEY => {}
     }
 
     p = property(obj, false)
@@ -120,32 +130,32 @@ class TestObjCProperty < Minitest::Test
   end
 
   def test_multiple_numeric_types
-    obj = { "type" => ["number", "integer", "boolean"] }
+    obj = { TYPE_KEY => ["number", "integer", "boolean"] }
     p = property(obj, false)
     assert_equal(:number_obj, p.type)
   end
 
   def test_typed_optional_multiple_numeric_types
-    obj = { "type" => ["number", "integer", "boolean", "null"] }
+    obj = { TYPE_KEY => ["number", "integer", "boolean", "null"] }
     p = property(obj, false)
     assert_equal(:number_obj, p.type)
     assert_equal(["Optional"], p.protocols)
   end
 
   def test_multiple_disparate_types
-    obj = { "type" => ["object", "number"] }
+    obj = { TYPE_KEY => ["object", "number"] }
     p = property(obj, false)
     assert_equal(:id, p.type)
   end
 
   def test_typed_optional_multiple_disparate_types
-    obj = { "type" => ["object", "number", "null"] }
+    obj = { TYPE_KEY => ["object", "number", "null"] }
     p = property(obj, false)
     assert_equal(:id, p.type)
   end
 
   def test_simple_numbers
-    obj = { "type" => [ "integer", "number" ] }
+    obj = { TYPE_KEY => [ "integer", "number" ] }
     p = property(obj, false)
     assert_equal(:number, p.type)
 
@@ -154,13 +164,13 @@ class TestObjCProperty < Minitest::Test
   end
 
   def test_typed_optional_simple_numbers
-    obj = { "type" => [ "integer", "number", "null" ] }
+    obj = { TYPE_KEY => [ "integer", "number", "null" ] }
     p = property(obj, false)
     assert_equal(:number_obj, p.type)
   end
 
   def test_integer_enum
-    obj = { "enum" => [1, 2] }
+    obj = { ENUM_KEY => [1, 2] }
     p = property(obj, false)
     assert_equal(:integer, p.type)
 
@@ -170,39 +180,39 @@ class TestObjCProperty < Minitest::Test
   end
 
   def test_string_enum
-    obj = { "enum" => ["a", "b"] }
+    obj = { ENUM_KEY => ["a", "b"] }
     p = property(obj, false)
     assert_equal(:string, p.type)
   end
 
   def test_typed_optional_enum
-    obj = { "enum" => [1, 2, nil] }
+    obj = { ENUM_KEY => [1, 2, nil] }
     p = property(obj, false)
     assert_equal(:number_obj, p.type)
     assert_equal(["Optional"], p.protocols)
   end
 
   def test_single_element_array_type
-    obj = { "type" => ["integer"] }
+    obj = { TYPE_KEY => ["integer"] }
     p = property(obj, false)
     assert_equal(:integer, p.type)
   end
 
   def test_anonymous_object
-    obj = { "type" => "object" }
+    obj = { TYPE_KEY => "object" }
     p = property(obj, false)
     assert_equal(:id, p.type)
   end
 
   def test_unsafe_getter
-    obj = { "type" => "integer" }
+    obj = { TYPE_KEY => "integer" }
     p = Nidyx::ObjCProperty.new(Nidyx::Property.new("newInt", nil, false, obj))
     assert_equal(", getter=getNewInt", p.getter_override)
   end
 
   def test_protocols
     obj = {
-      "type" => "array",
+      TYPE_KEY => "array",
       COLLECTION_TYPES_KEY => ["SomeModel", "OtherModel"]
     }
 
@@ -218,8 +228,8 @@ class TestObjCProperty < Minitest::Test
   end
 
   def test_unsupported_types_enum
-    assert_raises(Nidyx::ObjCProperty::UnsupportedEnumTypeError) do
-      obj = { "enum" => ["a", {}] }
+    assert_raises(Nidyx::ObjCUtils::UnsupportedEnumTypeError) do
+      obj = { ENUM_KEY => ["a", {}] }
       Nidyx::ObjCProperty.new(Nidyx::Property.new("i", nil, false, obj))
     end
   end
@@ -227,7 +237,7 @@ class TestObjCProperty < Minitest::Test
   private
 
   def simple_property(type)
-    obj = { "type" => type }
+    obj = { TYPE_KEY => type }
     Nidyx::ObjCProperty.new(Nidyx::Property.new("p", nil, false, obj))
   end
 

--- a/test/nidyx/test_parser.rb
+++ b/test/nidyx/test_parser.rb
@@ -196,7 +196,7 @@ class TestParser < Minitest::Test
           "type" => "array",
           "items" => [
             { "$ref" => "#/definitions/object" },
-            { "$ref" => "#/definitions/other_object" }
+            { "$ref" => "#/definitions/other_object" },
             { "type" => "string" }
           ]
         }
@@ -236,7 +236,7 @@ class TestParser < Minitest::Test
 
     multi_object_array = props.shift
     assert_equal(:array, multi_object_array.type)
-    assert_equal(%w(TSObjectModel TSOtherObjectModel), multi_object_array.collection_types)
+    assert_equal(%w(TSObjectModel TSOtherObjectModel string), multi_object_array.collection_types)
 
     # object model
     model = models["TSObjectModel"]

--- a/test/nidyx/test_parser.rb
+++ b/test/nidyx/test_parser.rb
@@ -197,6 +197,7 @@ class TestParser < Minitest::Test
           "items" => [
             { "$ref" => "#/definitions/object" },
             { "$ref" => "#/definitions/other_object" }
+            { "type" => "string" }
           ]
         }
       },
@@ -222,7 +223,7 @@ class TestParser < Minitest::Test
 
     # root model
     model = models["TSModel"]
-    assert_deps(%w(TSObjectModel TSOtherObjectModel), model)
+    assert_deps(%w(TSObjectModel TSOtherObjectModel string), model)
     props = model.properties
 
     string_array = props.shift


### PR DESCRIPTION
- Add handling parser.rb to handle constructs like { "type" => "string" } in the items list/hash for an array
- Fix ObjC parser to account for this (and move some functions into Utils modules)
- Update tests for parser and Obj properties
